### PR TITLE
End the animation with the logo filled in.

### DIFF
--- a/GridLogo/GridAnimatedLogo.swift
+++ b/GridLogo/GridAnimatedLogo.swift
@@ -31,7 +31,7 @@ public class AnimatedGridLogo: UIView {
     private var startPos: CGFloat = 0.0
     private var endPos: CGFloat = 1.0
     private var reverses = false
-    private var repeatCount: Float = 15.0
+    private var repeatCount: Float = 14.5
     private var lineWidth: CGFloat?
     
     override init(frame: CGRect) {


### PR DESCRIPTION
This is a quick hack so that the logo doesn't jump from completely filled in to empty when the animation stops.

I tried to do this a different way by making the background the gold color, the foreground the gray color, and flipping the easing around but it still created a jump at the end and left a weird thin stroke around the logo.
