### PR TITLE
Animate the opacity of the layers instead of the view.

### DIFF
--- a/GridLogo/GridAnimatedLogo.swift
+++ b/GridLogo/GridAnimatedLogo.swift
@@ -34,9 +34,26 @@ public class AnimatedGridLogo: UIView {
     private var repeatCount: Float = 14.5
     private var lineWidth: CGFloat?
     
+    private let fadeDuration = dispatch_time(DISPATCH_TIME_NOW, Int64(0.5 * Double(NSEC_PER_SEC)))
+    
+    let fadeInAnimation: CABasicAnimation = {
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.duration = 0.5
+        animation.fillMode = kCAFillModeForwards;
+        animation.fromValue = 0
+        return animation
+    }()
+    
+    let fadeOutAnimation: CABasicAnimation = {
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.duration = 0.5
+        animation.fillMode = kCAFillModeForwards;
+        animation.fromValue = 1
+        return animation
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
     }
     
     public convenience init(mystic: CGFloat, duration: CFTimeInterval, lineWidth: CGFloat?) {
@@ -65,7 +82,6 @@ public class AnimatedGridLogo: UIView {
     }
     
     func setup() {
-        self.alpha = 0
         self.md = CGFloat(mystic * mystic)
         self.strokeRatio = CGFloat(md) / CGFloat(mystic)
         self.userInteractionEnabled = false
@@ -124,21 +140,30 @@ public class AnimatedGridLogo: UIView {
     }
     
     public func show(completionHandler: (() -> Void)? = nil) {
-        UIView.animateWithDuration(0.5, animations: {
-            self.alpha = 1
-            self.startAnimation()
-        }, completion: { _ in
+        self.startAnimation()
+        
+        self.fgLayer?.opacity = 1
+        self.bgLayer?.opacity = 1
+        
+        self.fgLayer?.addAnimation(self.fadeInAnimation, forKey: "fade")
+        self.bgLayer?.addAnimation(self.fadeInAnimation, forKey: "fade")
+        
+        dispatch_after(self.fadeDuration, dispatch_get_main_queue()) {
             completionHandler?()
-        })
+        }
     }
     
     public func hide(completionHandler: (() -> Void)? = nil) {
-        UIView.animateWithDuration(0.5, animations: {
-            self.alpha = 0
-        }, completion: { _ in
-            self.endAnimation()
+        self.fgLayer?.opacity = 0
+        self.bgLayer?.opacity = 0
+        
+        self.fgLayer?.addAnimation(self.fadeOutAnimation, forKey: "fade")
+        self.bgLayer?.addAnimation(self.fadeOutAnimation, forKey: "fade")
+        
+        dispatch_after(self.fadeDuration, dispatch_get_main_queue()) {
+            self.fgLayer?.removeAllAnimations()
             completionHandler?()
-        })
+        }
     }
     
     func startAnimation() {


### PR DESCRIPTION
This addresses an issue where calling `hide()` would both cause the logo appear fully "colored in" with yellow, as well as prevent the fade in/out from appearing correctly.

This is because `hide()` previously called `endAnimation()` which called `self.fgLayer?.removeAllAnimations()`, and before the fade was complete.

[Animating Layer Content](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/CoreAnimation_guide/CreatingBasicAnimations/CreatingBasicAnimations.html) says:

> This method removes all ongoing animations immediately and redraws the layer using its current state information.

I found this solution while reading about a similar issue in a [post on Stack Overflow](http://stackoverflow.com/a/13853926/339925):

> ...set the FROM value in the animation and the TO value on the object. The animation will auto fill the TO value before it starts, and when it's removed will leave the object at it's correct state.
